### PR TITLE
fix plugin name to match Deployment-Name in pom.xml

### DIFF
--- a/src/main/java/org/osc/manager/ism/api/IsmApplianceManagerApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmApplianceManagerApi.java
@@ -46,7 +46,7 @@ property={
         PROVIDE_DEVICE_STATUS + ":Boolean=true",
         SYNC_POLICY_MAPPING + ":Boolean=false"})
 public class IsmApplianceManagerApi implements ApplianceManagerApi {
-    public static final String PLUGIN_NAME = "SMP";
+    static final String PLUGIN_NAME = "SMP";
 
     @Reference(target="(osgi.local.enabled=true)")
     private TransactionControl txControl;


### PR DESCRIPTION
fix plugin name to match Deployment-Name in pom.xml
which was changed in
commit 4bfe76371b62f6148f4f7b67ecf776dc4b7e0c19
Author: emanoel1 <emanoel.xavier@intel.com>
Date:   Thu Jan 26 19:22:52 2017 +0000