### PR TITLE
Fixes the INSTALL_WAIT issue. Brings deployment name in sync with Ism…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
 								<jar destfile="${project.build.directory}/SampleMgrPlugin.bar">
 									<fileset dir="${project.build.directory}/plugin" />
 									<manifest>
-										<attribute name="Deployment-Name" value="SMP" />
+										<attribute name="Deployment-Name" value="ISM" />
 										<attribute name="Deployment-Type" value="MANAGER"/>
 										<attribute name="Deployment-SymbolicName" value="SampleMgrPlugin" />
                                         <attribute name="Deployment-Version" value="${fullVersion}" />


### PR DESCRIPTION
Fixes the INSTALL_WAIT issue. Brings Deployment-Name header in sync with PLUGIN_NAME parameter in  IsmApplianceManagerApi.

To reproduce the issue, use the standard plugin installation procedure in OSC (i.e., in OSC Web UI, select Manage>Plugins, then ManagerPlugins tab, navigate to **target/SampleMgrPlugin.bar** in this project and upload).

After installation, the plugin will get stuck in INSTALL_WAIT state and never go to READY. The sdn-controller-nsc-plugin does not have the same issue. 