### PR TITLE
Replace logging with slf4j, backed by logback.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
 			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries.tx-control</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
 		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.aries.tx-control</groupId>
 			<artifactId>tx-control-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
 		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.aries.tx-control</groupId>
 			<artifactId>tx-control-api</artifactId>
@@ -182,12 +187,6 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.3.175</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.0</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
 		</dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-        </dependency>
 		<dependency>
 			<groupId>org.apache.aries.tx-control</groupId>
 			<artifactId>tx-control-api</artifactId>

--- a/src/main/java/org/osc/manager/ism/api/IsmAgentApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmAgentApi.java
@@ -21,17 +21,19 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.DeviceMemberEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerDeviceMemberApi;
 import org.osc.sdk.manager.element.ApplianceManagerConnectorElement;
 import org.osc.sdk.manager.element.DistributedApplianceInstanceElement;
 import org.osc.sdk.manager.element.ManagerDeviceMemberStatusElement;
 import org.osc.sdk.manager.element.VirtualSystemElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public final class IsmAgentApi implements ManagerDeviceMemberApi {
-    private static Logger LOG = Logger.getLogger(IsmAgentApi.class);
+
+    private static final Logger LOG = LogProvider.getLogger(IsmAgentApi.class);
     private IsmDeviceApi api;
     private TransactionControl txControl;
     private EntityManager em;

--- a/src/main/java/org/osc/manager/ism/api/IsmDeviceApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmDeviceApi.java
@@ -27,9 +27,9 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.DeviceEntity;
 import org.osc.manager.ism.entities.DeviceMemberEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerDeviceApi;
 import org.osc.sdk.manager.element.ApplianceBootstrapInformationElement;
 import org.osc.sdk.manager.element.BootStrapInfoProviderElement;
@@ -38,10 +38,11 @@ import org.osc.sdk.manager.element.ManagerDeviceElement;
 import org.osc.sdk.manager.element.ManagerDeviceMemberElement;
 import org.osc.sdk.manager.element.VirtualSystemElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public class IsmDeviceApi implements ManagerDeviceApi {
 
-    private static Logger LOG = Logger.getLogger(IsmDeviceApi.class);
+    private static final Logger LOG = LogProvider.getLogger(IsmDeviceApi.class);
     private VirtualSystemElement vs;
     private TransactionControl txControl;
     private EntityManager em;

--- a/src/main/java/org/osc/manager/ism/api/IsmDomainApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmDomainApi.java
@@ -24,15 +24,16 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.DomainEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerDomainApi;
 import org.osc.sdk.manager.element.ApplianceManagerConnectorElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public class IsmDomainApi implements ManagerDomainApi {
 
-    Logger log = Logger.getLogger(IsmDomainApi.class);
+    private static final Logger LOG = LogProvider.getLogger(IsmDomainApi.class);
     private TransactionControl txControl;
     private EntityManager em;
     ApplianceManagerConnectorElement mc;
@@ -57,7 +58,7 @@ public class IsmDomainApi implements ManagerDomainApi {
             @Override
             public DomainEntity call() throws Exception {
 
-                return em.find(DomainEntity.class, Long.parseLong(domainId));
+                return IsmDomainApi.this.em.find(DomainEntity.class, Long.parseLong(domainId));
             }
         });
     }
@@ -69,11 +70,11 @@ public class IsmDomainApi implements ManagerDomainApi {
 
             @Override
             public List<DomainEntity> call() throws Exception {
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = IsmDomainApi.this.em.getCriteriaBuilder();
                 CriteriaQuery<DomainEntity> query = criteriaBuilder.createQuery(DomainEntity.class);
                 Root<DomainEntity> r = query.from(DomainEntity.class);
                 query.select(r);
-                return em.createQuery(query).getResultList();
+                return IsmDomainApi.this.em.createQuery(query).getResultList();
             }
         });
     }

--- a/src/main/java/org/osc/manager/ism/api/IsmPolicyApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmPolicyApi.java
@@ -24,16 +24,17 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.DomainEntity;
 import org.osc.manager.ism.entities.PolicyEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerPolicyApi;
 import org.osc.sdk.manager.element.ApplianceManagerConnectorElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public class IsmPolicyApi implements ManagerPolicyApi {
 
-    Logger log = Logger.getLogger(IsmPolicyApi.class);
+    private static final Logger LOG = LogProvider.getLogger(IsmPolicyApi.class);
     private TransactionControl txControl;
     private EntityManager em;
     ApplianceManagerConnectorElement mc;
@@ -58,14 +59,14 @@ public class IsmPolicyApi implements ManagerPolicyApi {
             @Override
             public PolicyEntity call() throws Exception {
 
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = IsmPolicyApi.this.em.getCriteriaBuilder();
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r)
                         .where(criteriaBuilder.and(
                                 criteriaBuilder.equal(r.get("domain").get("id"), Long.parseLong(domainId)),
                                 criteriaBuilder.equal(r.get("id"), Long.parseLong(policyId))));
-                List<PolicyEntity> result = em.createQuery(query).getResultList();
+                List<PolicyEntity> result = IsmPolicyApi.this.em.createQuery(query).getResultList();
                 if (result.isEmpty()) {
                     throw new Exception("Policy or Domain Entity does not exists...");
                     //TODO - Add 404 error response - Sudhir
@@ -83,17 +84,17 @@ public class IsmPolicyApi implements ManagerPolicyApi {
             @Override
             public List<PolicyEntity> call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, Long.parseLong(domainId));
+                DomainEntity result = IsmPolicyApi.this.em.find(DomainEntity.class, Long.parseLong(domainId));
                 if (result == null) {
                     throw new Exception("Domain Entity does not exists...");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = IsmPolicyApi.this.em.getCriteriaBuilder();
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r).where(criteriaBuilder
                         .and(criteriaBuilder.equal(r.get("domain").get("id"), Long.parseLong(domainId))));
-                return em.createQuery(query).getResultList();
+                return IsmPolicyApi.this.em.createQuery(query).getResultList();
             }
         });
     }

--- a/src/main/java/org/osc/manager/ism/api/IsmSecurityGroupApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmSecurityGroupApi.java
@@ -24,17 +24,18 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.SecurityGroupEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerSecurityGroupApi;
 import org.osc.sdk.manager.element.ManagerSecurityGroupElement;
 import org.osc.sdk.manager.element.SecurityGroupMemberListElement;
 import org.osc.sdk.manager.element.VirtualSystemElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public class IsmSecurityGroupApi implements ManagerSecurityGroupApi {
 
-	private static final Logger LOGGER = Logger.getLogger(IsmSecurityGroupApi.class);
+	private static final Logger LOG = LogProvider.getLogger(IsmSecurityGroupApi.class);
 	private VirtualSystemElement vs;
 
 	private final TransactionControl txControl;
@@ -149,7 +150,7 @@ public class IsmSecurityGroupApi implements ManagerSecurityGroupApi {
 				try {
 					result = IsmSecurityGroupApi.this.em.createQuery(query).getSingleResult();
 				} catch (Exception e) {
-					LOGGER.error("Finding sg result in", e);
+					LOG.error("Finding sg result in", e);
 				}
 				return result == null ? null : result;
 			}
@@ -158,7 +159,7 @@ public class IsmSecurityGroupApi implements ManagerSecurityGroupApi {
 
 	@Override
 	public void close() {
-		LOGGER.info("Closing connection to the database");
+		LOG.info("Closing connection to the database");
 		this.txControl.required(() -> {
 			this.em.close();
 			return null;

--- a/src/main/java/org/osc/manager/ism/api/IsmSecurityGroupInterfaceApi.java
+++ b/src/main/java/org/osc/manager/ism/api/IsmSecurityGroupInterfaceApi.java
@@ -26,10 +26,10 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.PolicyEntity;
 import org.osc.manager.ism.entities.SecurityGroupEntity;
 import org.osc.manager.ism.entities.SecurityGroupInterfaceEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.sdk.manager.api.ManagerSecurityGroupInterfaceApi;
 import org.osc.sdk.manager.element.ApplianceManagerConnectorElement;
 import org.osc.sdk.manager.element.ManagerPolicyElement;
@@ -37,10 +37,11 @@ import org.osc.sdk.manager.element.ManagerSecurityGroupInterfaceElement;
 import org.osc.sdk.manager.element.SecurityGroupInterfaceElement;
 import org.osc.sdk.manager.element.VirtualSystemElement;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 public class IsmSecurityGroupInterfaceApi implements ManagerSecurityGroupInterfaceApi {
 
-	private static final Logger LOGGER = Logger.getLogger(IsmSecurityGroupInterfaceApi.class);
+	private static final Logger LOG = LogProvider.getLogger(IsmSecurityGroupInterfaceApi.class);
 	private static final String SGI_NOT_FOUND_MESSAGE = "A security group interface with id %s was not found.";
 
 	private final TransactionControl txControl;
@@ -109,7 +110,7 @@ public class IsmSecurityGroupInterfaceApi implements ManagerSecurityGroupInterfa
 	public void deleteSecurityGroupInterface(String id) throws Exception {
 		SecurityGroupInterfaceEntity existingSgi = getSecurityGroupInterface(id);
 		if (existingSgi == null) {
-			LOGGER.info(String.format(SGI_NOT_FOUND_MESSAGE, id));
+			LOG.info(String.format(SGI_NOT_FOUND_MESSAGE, id));
 			return;
 		}
 		this.txControl.required(new Callable<Void>() {
@@ -152,7 +153,7 @@ public class IsmSecurityGroupInterfaceApi implements ManagerSecurityGroupInterfa
 				try {
 					result = IsmSecurityGroupInterfaceApi.this.em.createQuery(query).getSingleResult();
 				} catch (Exception e) {
-					LOGGER.error("Finding sg result in", e);
+					LOG.error("Finding sg result in", e);
 				}
 				return result == null ? null : result.toString();
 			}
@@ -197,7 +198,7 @@ public class IsmSecurityGroupInterfaceApi implements ManagerSecurityGroupInterfa
 
 	@Override
 	public void close() {
-		LOGGER.info("Closing connection to the database");
+		LOG.info("Closing connection to the database");
 		this.txControl.required(() -> {
 			this.em.close();
 			return null;

--- a/src/main/java/org/osc/manager/ism/utils/LogProvider.java
+++ b/src/main/java/org/osc/manager/ism/utils/LogProvider.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.manager.ism.utils;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+@Component
+public class LogProvider {
+
+    private static ILoggerFactory loggerFactory;
+
+    @Reference
+    public void setLoggerFactoryInst(ILoggerFactory instance) {
+        loggerFactory = instance;
+    }
+
+    public static Logger getLogger(Object object) {
+        if (object == null) {
+            throw new IllegalArgumentException("Attempt to get logger for null class!!");
+        }
+
+        String className;
+        if (object instanceof Class) {
+            className = ((Class<?>) object).getName();
+        } else if (object instanceof String) {
+            className = (String) object;
+        } else {
+            className = object.getClass().getName();
+        }
+
+        return loggerFactory.getLogger(className);
+    }
+}

--- a/src/main/java/org/osc/manager/ism/utils/LogProvider.java
+++ b/src/main/java/org/osc/manager/ism/utils/LogProvider.java
@@ -16,19 +16,24 @@
  *******************************************************************************/
 package org.osc.manager.ism.utils;
 
-import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
+/**
+ * This component Takes the properly initialized {@link ILoggerFactory}
+ * service from OSGi uses it to create {@link Logger} objects for other
+ * classes via a static {@code getLogger} method.
+ *
+ * @see org.osc.core.broker.util.log
+ * @see org.osc.core.server.Server
+ */
 @Component
 public class LogProvider {
-    static ILoggerFactory loggerFactory;
+    private static ILoggerFactory loggerFactory;
 
-    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
+    @Reference
     public void setLoggerFactoryInst(ILoggerFactory instance) {
         setLoggerFactory(instance);
     }
@@ -41,7 +46,11 @@ public class LogProvider {
         return new LoggerProxy(clazz.getName());
     }
 
-    public static void setLoggerFactory(ILoggerFactory instance) {
+    public static ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    private static void setLoggerFactory(ILoggerFactory instance) {
         loggerFactory = instance;
     }
 }

--- a/src/main/java/org/osc/manager/ism/utils/LogProvider.java
+++ b/src/main/java/org/osc/manager/ism/utils/LogProvider.java
@@ -18,8 +18,6 @@ package org.osc.manager.ism.utils;
 
 import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -28,38 +26,22 @@ import org.slf4j.Logger;
 
 @Component
 public class LogProvider {
-    private static ConcurrentHashMap<String, Logger> loggerCache = new ConcurrentHashMap<>();
-
-    private static ILoggerFactory loggerFactory;
+    static ILoggerFactory loggerFactory;
 
     @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
     public void setLoggerFactoryInst(ILoggerFactory instance) {
         setLoggerFactory(instance);
     }
 
-    public static Logger getLogger(Object object) {
-        if (object == null) {
+    public static Logger getLogger(Class<?> clazz) {
+        if (clazz == null) {
             throw new IllegalArgumentException("Attempt to get logger for null class!!");
         }
 
-        String className;
-        if (object instanceof Class) {
-            className = ((Class<?>) object).getName();
-        } else if (object instanceof String) {
-            className = (String) object;
-        } else {
-            className = object.getClass().getName();
-        }
-
-        if (!loggerCache.containsKey(className)) {
-            loggerCache.put(className, new LoggerProxy(className, loggerFactory));
-        }
-
-        return loggerCache.get(className);
+        return new LoggerProxy(clazz.getName());
     }
 
     public static void setLoggerFactory(ILoggerFactory instance) {
         loggerFactory = instance;
     }
-
 }

--- a/src/main/java/org/osc/manager/ism/utils/LogProvider.java
+++ b/src/main/java/org/osc/manager/ism/utils/LogProvider.java
@@ -16,19 +16,25 @@
  *******************************************************************************/
 package org.osc.manager.ism.utils;
 
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 @Component
 public class LogProvider {
+    private static ConcurrentHashMap<String, Logger> loggerCache = new ConcurrentHashMap<>();
 
     private static ILoggerFactory loggerFactory;
 
-    @Reference
+    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
     public void setLoggerFactoryInst(ILoggerFactory instance) {
-        loggerFactory = instance;
+        setLoggerFactory(instance);
     }
 
     public static Logger getLogger(Object object) {
@@ -45,6 +51,15 @@ public class LogProvider {
             className = object.getClass().getName();
         }
 
-        return loggerFactory.getLogger(className);
+        if (!loggerCache.containsKey(className)) {
+            loggerCache.put(className, new LoggerProxy(className, loggerFactory));
+        }
+
+        return loggerCache.get(className);
     }
+
+    public static void setLoggerFactory(ILoggerFactory instance) {
+        loggerFactory = instance;
+    }
+
 }

--- a/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
+++ b/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
@@ -16,12 +16,17 @@
  *******************************************************************************/
 package org.osc.manager.ism.utils;
 
-import static org.osc.manager.ism.utils.LogProvider.loggerFactory;
+import static org.osc.manager.ism.utils.LogProvider.getLoggerFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
+/**
+ * Wrapper around the properly initialized {@link Logger}, once available from {@link LogProvider}.
+ * Delegates all the calls to that logger or to a standin logger in the meanwhile.
+ *
+ */
 class LoggerProxy implements Logger {
 
     private Logger properLogger;
@@ -343,8 +348,8 @@ class LoggerProxy implements Logger {
             return this.properLogger;
         }
 
-        if (loggerFactory != null) {
-            Logger implToUse = loggerFactory.getLogger(this.className);
+        if (getLoggerFactory() != null) {
+            Logger implToUse = getLoggerFactory().getLogger(this.className);
             synchronized (this) {
                 if (this.properLogger == null) {
                     this.properLogger = implToUse;

--- a/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
+++ b/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
@@ -1,0 +1,594 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.manager.ism.utils;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+public class LoggerProxy implements Logger {
+    private Logger properLogger;
+    private final Logger FALLBACK_IMPL;
+    private final String className;
+    private final ILoggerFactory loggerFactory;
+
+    public LoggerProxy(String className, ILoggerFactory atomicFactoryRef) {
+        this.className = className;
+        this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
+        this.loggerFactory = atomicFactoryRef;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isTraceEnabled();
+        } else {
+            return findImplToUse().isTraceEnabled();
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isTraceEnabled(marker);
+        } else {
+            return findImplToUse().isTraceEnabled(marker);
+        }
+    }
+
+    @Override
+    public void trace(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(msg);
+        } else {
+            findImplToUse().trace(msg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arg);
+        } else {
+            findImplToUse().trace(format, arg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arg1, arg2);
+        } else {
+            findImplToUse().trace(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arguments);
+        } else {
+            findImplToUse().trace(format, arguments);
+        }
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(msg, t);
+        } else {
+            findImplToUse().trace(msg, t);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, msg);
+        } else {
+            findImplToUse().trace(marker, msg);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, arg);
+        } else {
+            findImplToUse().trace(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().trace(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, argArray);
+        } else {
+            findImplToUse().trace(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, msg, t);
+        } else {
+            findImplToUse().trace(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isDebugEnabled();
+        } else {
+            return findImplToUse().isDebugEnabled();
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isDebugEnabled(marker);
+        } else {
+            return findImplToUse().isDebugEnabled(marker);
+        }
+    }
+
+    @Override
+    public void debug(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(msg);
+        } else {
+            findImplToUse().debug(msg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arg);
+        } else {
+            findImplToUse().debug(format, arg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arg1, arg2);
+        } else {
+            findImplToUse().debug(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arguments);
+        } else {
+            findImplToUse().debug(format, arguments);
+        }
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(msg, t);
+        } else {
+            findImplToUse().debug(msg, t);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, msg);
+        } else {
+            findImplToUse().debug(marker, msg);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, arg);
+        } else {
+            findImplToUse().debug(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().debug(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, argArray);
+        } else {
+            findImplToUse().debug(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, msg, t);
+        } else {
+            findImplToUse().debug(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isInfoEnabled();
+        } else {
+            return findImplToUse().isInfoEnabled();
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isInfoEnabled(marker);
+        } else {
+            return findImplToUse().isInfoEnabled(marker);
+        }
+    }
+
+    @Override
+    public void info(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(msg);
+        } else {
+            findImplToUse().info(msg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arg);
+        } else {
+            findImplToUse().info(format, arg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arg1, arg2);
+        } else {
+            findImplToUse().info(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void info(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arguments);
+        } else {
+            findImplToUse().info(format, arguments);
+        }
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.info(msg, t);
+        } else {
+            findImplToUse().info(msg, t);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, msg);
+        } else {
+            findImplToUse().info(marker, msg);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, arg);
+        } else {
+            findImplToUse().info(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().info(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, argArray);
+        } else {
+            findImplToUse().info(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, msg, t);
+        } else {
+            findImplToUse().info(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isWarnEnabled();
+        } else {
+            return findImplToUse().isWarnEnabled();
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isWarnEnabled(marker);
+        } else {
+            return findImplToUse().isWarnEnabled(marker);
+        }
+    }
+
+    @Override
+    public void warn(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(msg);
+        } else {
+            findImplToUse().warn(msg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arg);
+        } else {
+            findImplToUse().warn(format, arg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arg1, arg2);
+        } else {
+            findImplToUse().warn(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arguments);
+        } else {
+            findImplToUse().warn(format, arguments);
+        }
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(msg, t);
+        } else {
+            findImplToUse().warn(msg, t);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, msg);
+        } else {
+            findImplToUse().warn(marker, msg);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, arg);
+        } else {
+            findImplToUse().warn(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().warn(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, argArray);
+        } else {
+            findImplToUse().warn(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, msg, t);
+        } else {
+            findImplToUse().warn(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isErrorEnabled();
+        } else {
+            return findImplToUse().isErrorEnabled();
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isErrorEnabled(marker);
+        } else {
+            return findImplToUse().isErrorEnabled(marker);
+        }
+    }
+
+    @Override
+    public void error(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(msg);
+        } else {
+            findImplToUse().error(msg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arg);
+        } else {
+            findImplToUse().error(format, arg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arg1, arg2);
+        } else {
+            findImplToUse().error(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void error(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arguments);
+        } else {
+            findImplToUse().error(format, arguments);
+        }
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.error(msg, t);
+        } else {
+            findImplToUse().error(msg, t);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, msg);
+        } else {
+            findImplToUse().error(marker, msg);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, arg);
+        } else {
+            findImplToUse().error(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().error(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, argArray);
+        } else {
+            findImplToUse().error(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, msg, t);
+        } else {
+            findImplToUse().error(marker, msg, t);
+        }
+    }
+
+    private Logger findImplToUse() {
+        if (this.loggerFactory != null) {
+            Logger implToUse = this.loggerFactory.getLogger(this.className);
+            synchronized (this) {
+                if (this.properLogger == null) {
+                    this.properLogger = implToUse;
+                }
+            }
+            return this.properLogger;
+        } else {
+            return this.FALLBACK_IMPL;
+        }
+    }
+}

--- a/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
+++ b/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
@@ -19,8 +19,8 @@ package org.osc.manager.ism.utils;
 import static org.osc.manager.ism.utils.LogProvider.getLoggerFactory;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+import org.slf4j.impl.SimpleLoggerFactory;
 
 /**
  * Wrapper around the properly initialized {@link Logger}, once available from {@link LogProvider}.
@@ -35,7 +35,7 @@ class LoggerProxy implements Logger {
 
     public LoggerProxy(String className) {
         this.className = className;
-        this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
+        this.FALLBACK_IMPL = new SimpleLoggerFactory().getLogger(className);
     }
 
     @Override

--- a/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
+++ b/src/main/java/org/osc/manager/ism/utils/LoggerProxy.java
@@ -16,571 +16,335 @@
  *******************************************************************************/
 package org.osc.manager.ism.utils;
 
-import org.slf4j.ILoggerFactory;
+import static org.osc.manager.ism.utils.LogProvider.loggerFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
-public class LoggerProxy implements Logger {
+class LoggerProxy implements Logger {
+
     private Logger properLogger;
     private final Logger FALLBACK_IMPL;
     private final String className;
-    private final ILoggerFactory loggerFactory;
 
-    public LoggerProxy(String className, ILoggerFactory atomicFactoryRef) {
+    public LoggerProxy(String className) {
         this.className = className;
         this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
-        this.loggerFactory = atomicFactoryRef;
     }
 
     @Override
     public String getName() {
-        return null;
+        return this.className;
     }
 
     @Override
     public boolean isTraceEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isTraceEnabled();
-        } else {
-            return findImplToUse().isTraceEnabled();
-        }
+        return findImplToUse().isTraceEnabled();
     }
 
     @Override
     public boolean isTraceEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isTraceEnabled(marker);
-        } else {
-            return findImplToUse().isTraceEnabled(marker);
-        }
+        return findImplToUse().isTraceEnabled(marker);
     }
 
     @Override
     public void trace(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(msg);
-        } else {
-            findImplToUse().trace(msg);
-        }
+        findImplToUse().trace(msg);
     }
 
     @Override
     public void trace(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arg);
-        } else {
-            findImplToUse().trace(format, arg);
-        }
+        findImplToUse().trace(format, arg);
     }
 
     @Override
     public void trace(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arg1, arg2);
-        } else {
-            findImplToUse().trace(format, arg1, arg2);
-        }
+        findImplToUse().trace(format, arg1, arg2);
     }
 
     @Override
     public void trace(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arguments);
-        } else {
-            findImplToUse().trace(format, arguments);
-        }
+        findImplToUse().trace(format, arguments);
     }
 
     @Override
     public void trace(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(msg, t);
-        } else {
-            findImplToUse().trace(msg, t);
-        }
+        findImplToUse().trace(msg, t);
     }
 
     @Override
     public void trace(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, msg);
-        } else {
-            findImplToUse().trace(marker, msg);
-        }
+        findImplToUse().trace(marker, msg);
     }
 
     @Override
     public void trace(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, arg);
-        } else {
-            findImplToUse().trace(marker, format, arg);
-        }
+        findImplToUse().trace(marker, format, arg);
     }
 
     @Override
     public void trace(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().trace(marker, format, arg1, arg2);
-        }
+        findImplToUse().trace(marker, format, arg1, arg2);
     }
 
     @Override
     public void trace(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, argArray);
-        } else {
-            findImplToUse().trace(marker, format, argArray);
-        }
+        findImplToUse().trace(marker, format, argArray);
     }
 
     @Override
     public void trace(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, msg, t);
-        } else {
-            findImplToUse().trace(marker, msg, t);
-        }
+        findImplToUse().trace(marker, msg, t);
     }
 
     @Override
     public boolean isDebugEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isDebugEnabled();
-        } else {
-            return findImplToUse().isDebugEnabled();
-        }
+        return findImplToUse().isDebugEnabled();
     }
 
     @Override
     public boolean isDebugEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isDebugEnabled(marker);
-        } else {
-            return findImplToUse().isDebugEnabled(marker);
-        }
+        return findImplToUse().isDebugEnabled(marker);
     }
 
     @Override
     public void debug(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(msg);
-        } else {
-            findImplToUse().debug(msg);
-        }
+        findImplToUse().debug(msg);
     }
 
     @Override
     public void debug(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arg);
-        } else {
-            findImplToUse().debug(format, arg);
-        }
+        findImplToUse().debug(format, arg);
     }
 
     @Override
     public void debug(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arg1, arg2);
-        } else {
-            findImplToUse().debug(format, arg1, arg2);
-        }
+        findImplToUse().debug(format, arg1, arg2);
     }
 
     @Override
     public void debug(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arguments);
-        } else {
-            findImplToUse().debug(format, arguments);
-        }
+        findImplToUse().debug(format, arguments);
     }
 
     @Override
     public void debug(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(msg, t);
-        } else {
-            findImplToUse().debug(msg, t);
-        }
+        findImplToUse().debug(msg, t);
     }
 
     @Override
     public void debug(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, msg);
-        } else {
-            findImplToUse().debug(marker, msg);
-        }
+        findImplToUse().debug(marker, msg);
     }
 
     @Override
     public void debug(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, arg);
-        } else {
-            findImplToUse().debug(marker, format, arg);
-        }
+        findImplToUse().debug(marker, format, arg);
     }
 
     @Override
     public void debug(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().debug(marker, format, arg1, arg2);
-        }
+        findImplToUse().debug(marker, format, arg1, arg2);
     }
 
     @Override
     public void debug(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, argArray);
-        } else {
-            findImplToUse().debug(marker, format, argArray);
-        }
+        findImplToUse().debug(marker, format, argArray);
     }
 
     @Override
     public void debug(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, msg, t);
-        } else {
-            findImplToUse().debug(marker, msg, t);
-        }
+        findImplToUse().debug(marker, msg, t);
     }
 
     @Override
     public boolean isInfoEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isInfoEnabled();
-        } else {
-            return findImplToUse().isInfoEnabled();
-        }
+        return findImplToUse().isInfoEnabled();
     }
 
     @Override
     public boolean isInfoEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isInfoEnabled(marker);
-        } else {
-            return findImplToUse().isInfoEnabled(marker);
-        }
+        return findImplToUse().isInfoEnabled(marker);
     }
 
     @Override
     public void info(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(msg);
-        } else {
-            findImplToUse().info(msg);
-        }
+        findImplToUse().info(msg);
     }
 
     @Override
     public void info(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arg);
-        } else {
-            findImplToUse().info(format, arg);
-        }
+        findImplToUse().info(format, arg);
     }
 
     @Override
     public void info(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arg1, arg2);
-        } else {
-            findImplToUse().info(format, arg1, arg2);
-        }
+        findImplToUse().info(format, arg1, arg2);
     }
 
     @Override
     public void info(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arguments);
-        } else {
-            findImplToUse().info(format, arguments);
-        }
+        findImplToUse().info(format, arguments);
     }
 
     @Override
     public void info(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.info(msg, t);
-        } else {
-            findImplToUse().info(msg, t);
-        }
+        findImplToUse().info(msg, t);
     }
 
     @Override
     public void info(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, msg);
-        } else {
-            findImplToUse().info(marker, msg);
-        }
+        findImplToUse().info(marker, msg);
     }
 
     @Override
     public void info(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, arg);
-        } else {
-            findImplToUse().info(marker, format, arg);
-        }
+        findImplToUse().info(marker, format, arg);
     }
 
     @Override
     public void info(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().info(marker, format, arg1, arg2);
-        }
+        findImplToUse().info(marker, format, arg1, arg2);
     }
 
     @Override
     public void info(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, argArray);
-        } else {
-            findImplToUse().info(marker, format, argArray);
-        }
+        findImplToUse().info(marker, format, argArray);
     }
 
     @Override
     public void info(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, msg, t);
-        } else {
-            findImplToUse().info(marker, msg, t);
-        }
+        findImplToUse().info(marker, msg, t);
     }
 
     @Override
     public boolean isWarnEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isWarnEnabled();
-        } else {
-            return findImplToUse().isWarnEnabled();
-        }
+        return findImplToUse().isWarnEnabled();
     }
 
     @Override
     public boolean isWarnEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isWarnEnabled(marker);
-        } else {
-            return findImplToUse().isWarnEnabled(marker);
-        }
+        return findImplToUse().isWarnEnabled(marker);
     }
 
     @Override
     public void warn(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(msg);
-        } else {
-            findImplToUse().warn(msg);
-        }
+        findImplToUse().warn(msg);
     }
 
     @Override
     public void warn(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arg);
-        } else {
-            findImplToUse().warn(format, arg);
-        }
+        findImplToUse().warn(format, arg);
     }
 
     @Override
     public void warn(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arg1, arg2);
-        } else {
-            findImplToUse().warn(format, arg1, arg2);
-        }
+        findImplToUse().warn(format, arg1, arg2);
     }
 
     @Override
     public void warn(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arguments);
-        } else {
-            findImplToUse().warn(format, arguments);
-        }
+        findImplToUse().warn(format, arguments);
     }
 
     @Override
     public void warn(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(msg, t);
-        } else {
-            findImplToUse().warn(msg, t);
-        }
+        findImplToUse().warn(msg, t);
     }
 
     @Override
     public void warn(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, msg);
-        } else {
-            findImplToUse().warn(marker, msg);
-        }
+        findImplToUse().warn(marker, msg);
     }
 
     @Override
     public void warn(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, arg);
-        } else {
-            findImplToUse().warn(marker, format, arg);
-        }
+        findImplToUse().warn(marker, format, arg);
     }
 
     @Override
     public void warn(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().warn(marker, format, arg1, arg2);
-        }
+        findImplToUse().warn(marker, format, arg1, arg2);
     }
 
     @Override
     public void warn(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, argArray);
-        } else {
-            findImplToUse().warn(marker, format, argArray);
-        }
+        findImplToUse().warn(marker, format, argArray);
     }
 
     @Override
     public void warn(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, msg, t);
-        } else {
-            findImplToUse().warn(marker, msg, t);
-        }
+        findImplToUse().warn(marker, msg, t);
     }
 
     @Override
     public boolean isErrorEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isErrorEnabled();
-        } else {
-            return findImplToUse().isErrorEnabled();
-        }
+        return findImplToUse().isErrorEnabled();
     }
 
     @Override
     public boolean isErrorEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isErrorEnabled(marker);
-        } else {
-            return findImplToUse().isErrorEnabled(marker);
-        }
+        return findImplToUse().isErrorEnabled(marker);
     }
 
     @Override
     public void error(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(msg);
-        } else {
-            findImplToUse().error(msg);
-        }
+        findImplToUse().error(msg);
     }
 
     @Override
     public void error(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arg);
-        } else {
-            findImplToUse().error(format, arg);
-        }
+        findImplToUse().error(format, arg);
     }
 
     @Override
     public void error(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arg1, arg2);
-        } else {
-            findImplToUse().error(format, arg1, arg2);
-        }
+        findImplToUse().error(format, arg1, arg2);
     }
 
     @Override
     public void error(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arguments);
-        } else {
-            findImplToUse().error(format, arguments);
-        }
+        findImplToUse().error(format, arguments);
     }
 
     @Override
     public void error(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.error(msg, t);
-        } else {
-            findImplToUse().error(msg, t);
-        }
+        findImplToUse().error(msg, t);
     }
 
     @Override
     public void error(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, msg);
-        } else {
-            findImplToUse().error(marker, msg);
-        }
+        findImplToUse().error(marker, msg);
     }
 
     @Override
     public void error(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, arg);
-        } else {
-            findImplToUse().error(marker, format, arg);
-        }
+        findImplToUse().error(marker, format, arg);
     }
 
     @Override
     public void error(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().error(marker, format, arg1, arg2);
-        }
+        findImplToUse().error(marker, format, arg1, arg2);
     }
 
     @Override
     public void error(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, argArray);
-        } else {
-            findImplToUse().error(marker, format, argArray);
-        }
+        findImplToUse().error(marker, format, argArray);
     }
 
     @Override
     public void error(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, msg, t);
-        } else {
-            findImplToUse().error(marker, msg, t);
-        }
+        findImplToUse().error(marker, msg, t);
     }
 
     private Logger findImplToUse() {
-        if (this.loggerFactory != null) {
-            Logger implToUse = this.loggerFactory.getLogger(this.className);
+        if (this.properLogger != null) {
+            return this.properLogger;
+        }
+
+        if (loggerFactory != null) {
+            Logger implToUse = loggerFactory.getLogger(this.className);
             synchronized (this) {
                 if (this.properLogger == null) {
                     this.properLogger = implToUse;

--- a/src/main/java/org/osc/manager/rest/server/api/DeviceApis.java
+++ b/src/main/java/org/osc/manager/rest/server/api/DeviceApis.java
@@ -32,21 +32,22 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.api.IsmDeviceApi;
 import org.osc.manager.ism.entities.DeviceEntity;
 import org.osc.manager.ism.entities.DeviceMemberEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.manager.rest.server.SecurityManagerServerRestConstants;
 import org.osc.sdk.manager.element.ManagerDeviceElement;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 @Component(service = DeviceApis.class)
 @Path(SecurityManagerServerRestConstants.SERVER_API_PATH_PREFIX + "/devices")
 @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 public class DeviceApis {
-    private static final Logger LOG = Logger.getLogger(DeviceApis.class);
+    private static final Logger LOG = LogProvider.getLogger(DeviceApis.class);
     private EntityManager em;
     private TransactionControl txControl;
     private IsmDeviceApi api;

--- a/src/main/java/org/osc/manager/rest/server/api/DomainApis.java
+++ b/src/main/java/org/osc/manager/rest/server/api/DomainApis.java
@@ -34,12 +34,13 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.log4j.Logger;
 import org.osc.manager.ism.entities.DomainEntity;
 import org.osc.manager.ism.entities.PolicyEntity;
+import org.osc.manager.ism.utils.LogProvider;
 import org.osc.manager.rest.server.SecurityManagerServerRestConstants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.transaction.control.TransactionControl;
+import org.slf4j.Logger;
 
 @Component(service = DomainApis.class)
 @Path(SecurityManagerServerRestConstants.SERVER_API_PATH_PREFIX + "/domains")
@@ -48,7 +49,7 @@ import org.osgi.service.transaction.control.TransactionControl;
 
 public class DomainApis {
 
-    private static final Logger logger = Logger.getLogger(DomainApis.class);
+    private static final Logger LOG = LogProvider.getLogger(DomainApis.class);
     private EntityManager em;
     private TransactionControl txControl;
 
@@ -71,30 +72,30 @@ public class DomainApis {
     @POST
     public String createPolicy(@PathParam("domainId") Long domainId, PolicyEntity entity) {
 
-        logger.info("Creating Policy Entity...:" + entity.getName());
+        LOG.info("Creating Policy Entity...:" + entity.getName());
 
         return this.txControl.required(new Callable<PolicyEntity>() {
 
             @Override
             public PolicyEntity call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, domainId);
+                DomainEntity result = DomainApis.this.em.find(DomainEntity.class, domainId);
                 if (result == null) {
                     throw new Exception("Domain Entity does not exists...");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r).where(criteriaBuilder.and(criteriaBuilder.equal(r.get("name"), entity.getName())));
 
-                List<PolicyEntity> policyresult = em.createQuery(query).getResultList();
+                List<PolicyEntity> policyresult = DomainApis.this.em.createQuery(query).getResultList();
                 if (!policyresult.isEmpty()) {
                     throw new Exception("Policy Entity name already exists...:");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
                 entity.setDomain(result);
-                em.persist(entity);
+                DomainApis.this.em.persist(entity);
                 return entity;
             }
         }).getId();
@@ -110,27 +111,27 @@ public class DomainApis {
     public PolicyEntity updatePolicy(@PathParam("domainId") Long domainId, @PathParam("policyId") Long policyId,
             PolicyEntity entity) {
 
-        logger.info("Updating for Policy Entity Id...:" + policyId);
+        LOG.info("Updating for Policy Entity Id...:" + policyId);
 
         return this.txControl.required(new Callable<PolicyEntity>() {
 
             @Override
             public PolicyEntity call() throws Exception {
 
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
 
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r).where(criteriaBuilder.and(criteriaBuilder.equal(r.get("domain").get("id"), domainId)),
                         criteriaBuilder.equal(r.get("id"), policyId));
 
-                List<PolicyEntity> result = em.createQuery(query).getResultList();
+                List<PolicyEntity> result = DomainApis.this.em.createQuery(query).getResultList();
                 if (result.isEmpty()) {
                     throw new Exception("domain or the policy Entity does not exists...");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
                 result.get(0).setName(entity.getName());
-                em.persist(result.get(0));
+                DomainApis.this.em.persist(result.get(0));
                 return result.get(0);
             }
         });
@@ -146,22 +147,22 @@ public class DomainApis {
     public void deletePolicy(@PathParam("domainId") Long domainId, @PathParam("policyId") Long policyId,
             PolicyEntity entity) {
 
-        logger.info("Deleting for Policies Entity Id...:" + policyId);
+        LOG.info("Deleting for Policies Entity Id...:" + policyId);
 
         this.txControl.required(new Callable<Void>() {
 
             @Override
             public Void call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, domainId);
+                DomainEntity result = DomainApis.this.em.find(DomainEntity.class, domainId);
                 if (result == null) {
                     return null;
                 }
-                PolicyEntity policyresult = em.find(PolicyEntity.class, policyId);
+                PolicyEntity policyresult = DomainApis.this.em.find(PolicyEntity.class, policyId);
                 if (policyresult == null) {
                     return null;
                 }
-                em.remove(policyresult);
+                DomainApis.this.em.remove(policyresult);
                 return null;
             }
         });
@@ -176,7 +177,7 @@ public class DomainApis {
     @GET
     public List<String> getPolicyIds(@PathParam("domainId") Long domainId) {
 
-        logger.info("Listing Policy Ids'for domain Id ...:" + domainId);
+        LOG.info("Listing Policy Ids'for domain Id ...:" + domainId);
 
 
         return this.txControl.supports(new Callable<List<String>>() {
@@ -184,16 +185,16 @@ public class DomainApis {
             @Override
             public List<String> call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, domainId);
+                DomainEntity result = DomainApis.this.em.find(DomainEntity.class, domainId);
                 if (result == null) {
                     throw new Exception("Domain Entity does not exists...");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r).where(criteriaBuilder.and(criteriaBuilder.equal(r.get("domain").get("id"), domainId)));
-                List<PolicyEntity> policyList = em.createQuery(query).getResultList();
+                List<PolicyEntity> policyList = DomainApis.this.em.createQuery(query).getResultList();
                 List<String> policies = new ArrayList<String>();
                 if (policyList.isEmpty()) {
                     return policies;
@@ -218,18 +219,18 @@ public class DomainApis {
     public PolicyEntity getPolicy(@PathParam("domainId") Long domainId, @PathParam("policyId") Long policyId)
             throws Exception {
 
-        logger.info("getting Policy for Policy ID..:" + policyId);
+        LOG.info("getting Policy for Policy ID..:" + policyId);
 
         return this.txControl.supports(new Callable<PolicyEntity>() {
 
             @Override
             public PolicyEntity call() throws Exception {
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
                 CriteriaQuery<PolicyEntity> query = criteriaBuilder.createQuery(PolicyEntity.class);
                 Root<PolicyEntity> r = query.from(PolicyEntity.class);
                 query.select(r).where(criteriaBuilder.and(criteriaBuilder.equal(r.get("domain").get("id"), domainId),
                         criteriaBuilder.equal(r.get("id"), policyId)));
-                List<PolicyEntity> result = em.createQuery(query).getResultList();
+                List<PolicyEntity> result = DomainApis.this.em.createQuery(query).getResultList();
                 if (result.isEmpty()) {
                     throw new Exception("Policy or Domain Entity does not exists...");
                     //TODO - Add 404 error response - Sudhir
@@ -247,24 +248,24 @@ public class DomainApis {
     @POST
     public String createDomain(DomainEntity entity) {
 
-        logger.info("Creating Domain Entity...:" + entity.getName());
+        LOG.info("Creating Domain Entity...:" + entity.getName());
 
         return this.txControl.required(new Callable<DomainEntity>() {
 
             @Override
             public DomainEntity call() throws Exception {
 
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
                 CriteriaQuery<DomainEntity> query = criteriaBuilder.createQuery(DomainEntity.class);
                 Root<DomainEntity> r = query.from(DomainEntity.class);
                 query.select(r).where(criteriaBuilder.and(criteriaBuilder.equal(r.get("name"), entity.getName())));
 
-                List<DomainEntity> result = em.createQuery(query).getResultList();
+                List<DomainEntity> result = DomainApis.this.em.createQuery(query).getResultList();
                 if (!result.isEmpty()) {
                     throw new Exception("Domain name already exists...");
                     //TODO - to add RETURN 400 error:Sudhir
                 }
-                em.persist(entity);
+                DomainApis.this.em.persist(entity);
                 return entity;
             }
         }).getId();
@@ -279,20 +280,20 @@ public class DomainApis {
     @PUT
     public DomainEntity updateDomain(@PathParam("domainId") Long domainId, DomainEntity entity) {
 
-        logger.info("Updating Domain Entity ID...:" + domainId);
+        LOG.info("Updating Domain Entity ID...:" + domainId);
 
         return this.txControl.required(new Callable<DomainEntity>() {
 
             @Override
             public DomainEntity call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, domainId);
+                DomainEntity result = DomainApis.this.em.find(DomainEntity.class, domainId);
                 if (result == null) {
                     throw new Exception("Domain Entity does not exists...");
                     //TODO - to add RETURN 404 error:Sudhir
                 }
                 result.setName(entity.getName());
-                em.persist(result);
+                DomainApis.this.em.persist(result);
                 return result;
             }
         });
@@ -307,18 +308,18 @@ public class DomainApis {
     @DELETE
     public void deleteDomain(@PathParam("domainId") Long domainId) {
 
-        logger.info("Deleting Domain Entity ID...:" + domainId);
+        LOG.info("Deleting Domain Entity ID...:" + domainId);
 
         this.txControl.required(new Callable<Void>() {
 
             @Override
             public Void call() throws Exception {
 
-                DomainEntity result = em.find(DomainEntity.class, domainId);
+                DomainEntity result = DomainApis.this.em.find(DomainEntity.class, domainId);
                 if (result == null) {
                     return null;
                 }
-                em.remove(result);
+                DomainApis.this.em.remove(result);
                 return null;
             }
         });
@@ -332,18 +333,18 @@ public class DomainApis {
     @GET
     public List<String> getDomainIds() {
 
-        logger.info("Listing Domain Ids'");
+        LOG.info("Listing Domain Ids'");
 
         return this.txControl.supports(new Callable<List<String>>() {
 
             @Override
             public List<String> call() throws Exception {
 
-                CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+                CriteriaBuilder criteriaBuilder = DomainApis.this.em.getCriteriaBuilder();
                 CriteriaQuery<DomainEntity> query = criteriaBuilder.createQuery(DomainEntity.class);
                 Root<DomainEntity> r = query.from(DomainEntity.class);
                 query.select(r);
-                List<DomainEntity> result = em.createQuery(query).getResultList();
+                List<DomainEntity> result = DomainApis.this.em.createQuery(query).getResultList();
                 List<String> domainList = new ArrayList<String>();
                 if (result.isEmpty()) {
                     return domainList;
@@ -367,14 +368,14 @@ public class DomainApis {
     @GET
     public DomainEntity getDomain(@PathParam("domainId") Long domainId) throws Exception {
 
-        logger.info("getting Domain for ID...:" + domainId);
+        LOG.info("getting Domain for ID...:" + domainId);
 
         return this.txControl.supports(new Callable<DomainEntity>() {
 
             @Override
             public DomainEntity call() throws Exception {
 
-                return em.find(DomainEntity.class, Long.valueOf(domainId));
+                return DomainApis.this.em.find(DomainEntity.class, Long.valueOf(domainId));
             }
         });
     }

--- a/src/test/java/org/osc/ism/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/ism/OSGiIntegrationTest.java
@@ -123,7 +123,9 @@ public class OSGiIntegrationTest {
 
                 mavenBundle("org.osc.api", "security-mgr-api").versionAsInProject(),
                 mavenBundle("javax.websocket", "javax.websocket-api").versionAsInProject(),
-                mavenBundle("log4j", "log4j").versionAsInProject(),
+                mavenBundle("slf4j-api", "slf4j-api").versionAsInProject(),
+                mavenBundle("slf4j-simple", "slf4j-simple").versionAsInProject(),
+
                 mavenBundle("org.apache.aries.jpa", "org.apache.aries.jpa.container").versionAsInProject(),
                 mavenBundle("org.apache.aries.tx-control", "tx-control-service-local").versionAsInProject(),
                 mavenBundle("org.apache.aries.tx-control", "tx-control-provider-jpa-local").versionAsInProject(),

--- a/src/test/java/org/osc/ism/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/ism/OSGiIntegrationTest.java
@@ -124,6 +124,8 @@ public class OSGiIntegrationTest {
                 mavenBundle("org.osc.api", "security-mgr-api").versionAsInProject(),
                 mavenBundle("javax.websocket", "javax.websocket-api").versionAsInProject(),
                 mavenBundle("org.slf4j", "slf4j-api").versionAsInProject(),
+                // Fragment bundles cannot be started
+                mavenBundle("org.slf4j", "slf4j-simple").versionAsInProject().noStart(),
 
                 mavenBundle("org.apache.aries.jpa", "org.apache.aries.jpa.container").versionAsInProject(),
                 mavenBundle("org.apache.aries.tx-control", "tx-control-service-local").versionAsInProject(),

--- a/src/test/java/org/osc/ism/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/ism/OSGiIntegrationTest.java
@@ -123,8 +123,7 @@ public class OSGiIntegrationTest {
 
                 mavenBundle("org.osc.api", "security-mgr-api").versionAsInProject(),
                 mavenBundle("javax.websocket", "javax.websocket-api").versionAsInProject(),
-                mavenBundle("slf4j-api", "slf4j-api").versionAsInProject(),
-                mavenBundle("slf4j-simple", "slf4j-simple").versionAsInProject(),
+                mavenBundle("org.slf4j", "slf4j-api").versionAsInProject(),
 
                 mavenBundle("org.apache.aries.jpa", "org.apache.aries.jpa.container").versionAsInProject(),
                 mavenBundle("org.apache.aries.tx-control", "tx-control-service-local").versionAsInProject(),


### PR DESCRIPTION
* SFL4j is used in all non-core components. 
* logback is the logging framework used in osc-server. Easy to replace.
* osc-server publishes ILoggerFactory implementation for all other bundles.
* Witnessed logging functionality in osc-server, osc-ui and the NSC plugin.
* No mention of log4j anywhere in the project.